### PR TITLE
Issue #2: Adding new tab support for mac os x. 

### DIFF
--- a/build/chrome/content/switcherOverlay.js
+++ b/build/chrome/content/switcherOverlay.js
@@ -157,7 +157,7 @@ SwitcherListener.prototype.EnableDisplay = function(displayNode, toolTipText) {
  */
 SwitcherListener.prototype.handleEvent = function(event) {
   var newtab = false; // open in new tab?
-  if(event.button == 1 || (event.button == 0 && event.ctrlKey)) { // middle button or CTRL+leftclick
+  if(event.button == 1 || (event.button == 0 && (event.ctrlKey || event.metaKey))) { // middle button or CTRL+leftclick or CMD+leftclick
     newtab = true;
   }
   else if(event.button == 0 || (event.ctrlKey && event.shiftKey && event.charCode == '88')); // left mouse or key combo


### PR DESCRIPTION
Check for meta key (cmd) during click event.

References:
https://developer.mozilla.org/en-US/docs/DOM/event.metaKey
http://stackoverflow.com/questions/5604538/how-to-check-cmdclick
http://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_onmousedown2
